### PR TITLE
[UI/UX] Highlight edited service entries

### DIFF
--- a/pg_service_parser/core/item_models.py
+++ b/pg_service_parser/core/item_models.py
@@ -47,7 +47,7 @@ class ServiceConfigModel(QAbstractTableModel):
                 return font
         elif role == Qt.ForegroundRole and index.column() == self.VALUE_COL:
             if self.__model_data[key] != self.__original_data[key]:
-                return QColorConstants.Red
+                return QColorConstants.DarkGreen
 
         return None
 

--- a/pg_service_parser/core/item_models.py
+++ b/pg_service_parser/core/item_models.py
@@ -1,10 +1,12 @@
-from qgis.PyQt.QtCore import QAbstractTableModel, Qt
+from qgis.PyQt.QtCore import QAbstractTableModel, Qt, pyqtSignal
 from qgis.PyQt.QtGui import QFont
 
 
 class ServiceConfigModel(QAbstractTableModel):
     KEY_COL = 0
     VALUE_COL = 1
+
+    is_dirty_changed = pyqtSignal(bool)  # Whether the model gets dirty or not
 
     def __init__(self, service_name, service_config):
         super().__init__()
@@ -45,6 +47,7 @@ class ServiceConfigModel(QAbstractTableModel):
         if value != self.__model_data[key]:
             self.__model_data[key] = value
             self.__dirty = True
+            self.is_dirty_changed.emit(True)
             return True
 
         return False
@@ -70,3 +73,4 @@ class ServiceConfigModel(QAbstractTableModel):
 
     def set_not_dirty(self):
         self.__dirty = False
+        self.is_dirty_changed.emit(False)

--- a/pg_service_parser/gui/dlg_pg_service.py
+++ b/pg_service_parser/gui/dlg_pg_service.py
@@ -154,6 +154,8 @@ class PgServiceDialog(QDialog, DIALOG_UI):
 
         self.__edit_model = ServiceConfigModel(target_service, service_config(target_service))
         self.tblServiceConfig.setModel(self.__edit_model)
+        self.__edit_model.is_dirty_changed.connect(self.btnUpdateService.setEnabled)
+        self.btnUpdateService.setDisabled(True)
 
     @pyqtSlot()
     def __update_service_clicked(self):


### PR DESCRIPTION
Fix #23 


https://github.com/opengisch/qgis-pg-service-parser-plugin/assets/652785/048400f8-78f8-44df-bed6-2cc61a7d8d70

Features:
 + Edited entry is highlighted in red and italics.
 + An edited entry leads to enable the `Update service` button.
 + Reedited values that return to their original stored value, go back to initial state (black and no italics). If the reedited value makes all values correspond to their original state, the `Update service` button is disabled, since there's nothing to save.
 + Once edited values are saved, they go back to initial state (black and no italics) and the `Update service` button gets disabled.