### PR TITLE
Make sure QGIS can reload the underlying lib

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
-pg_service_parser/libs
+pg_service_parser/libs/
+!pg_service_parser/libs/__init__.py
 .idea
 __pycache__


### PR DESCRIPTION
Add `__init__.py` to `libs/` so that QGIS understands we've got a subpackage in `libs/` and can reload it when reloading or upgrading the plugin.

Fix #33 