### PR TITLE
[fix] Use new Enum only for QGIS 3.39+

### DIFF
--- a/pg_service_parser/core/service_connections.py
+++ b/pg_service_parser/core/service_connections.py
@@ -1,4 +1,5 @@
 from qgis.core import (
+    Qgis,
     QgsAbstractDatabaseProviderConnection,
     QgsDataSourceUri,
     QgsProviderRegistry,
@@ -37,9 +38,12 @@ def edit_connection(connection_name: str, parent: QWidget) -> None:
 
     if connection_name in provider.dbConnections():
         pg = QgsGui.sourceSelectProviderRegistry().providerByName("postgres")
-        widget = pg.createDataSourceWidget(
-            parent, widgetMode=QgsProviderRegistry.WidgetMode.Standalone
-        )
+        if Qgis.QGIS_VERSION_INT >= 33900:
+            widget_mode = QgsProviderRegistry.WidgetMode.Standalone
+        else:
+            widget_mode = QgsProviderRegistry.WidgetMode.None_
+
+        widget = pg.createDataSourceWidget(parent, widgetMode=widget_mode)
 
         settings = QSettings()
         settings.setValue("PostgreSQL/connections/selected", connection_name)


### PR DESCRIPTION
Fix #52 

Since this fixes broken functionality for QGIS 3.38 and below, please release once merged.