### PR TITLE
[core] Refactor settings handling to allow for multiple custom widgets

### DIFF
--- a/pg_service_parser/conf/enums.py
+++ b/pg_service_parser/conf/enums.py
@@ -8,3 +8,8 @@ class SslModeEnum(Enum):
     REQUIRE = "require"
     VERIFY_CA = "verify-ca"
     VERIFY_FULL = "verify-full"
+
+
+class WidgetTypeEnum(Enum):
+    COMBOBOX = 0
+    FILEWIDGET = 1

--- a/pg_service_parser/conf/service_settings.py
+++ b/pg_service_parser/conf/service_settings.py
@@ -1,4 +1,4 @@
-from pg_service_parser.conf.enums import SslModeEnum
+from pg_service_parser.conf.enums import SslModeEnum, WidgetTypeEnum
 
 # Settings available for manual addition
 # See https://www.postgresql.org/docs/current/libpq-connect.html#LIBPQ-PARAMKEYWORDS
@@ -11,14 +11,51 @@ SERVICE_SETTINGS = {
         "default": "",
         "description": "Password to be used if the server demands password authentication.",
     },
-    "sslmode": {
-        "default": SslModeEnum.PREFER.value,
-        "description": "This option determines whether or with what priority a secure SSL TCP/IP connection will be negotiated with the server.",
-        "values": SslModeEnum,
-    },
     "passfile": {
         "default": "",
         "description": "Specifies the name of the file used to store passwords.",
+        "custom_type": WidgetTypeEnum.FILEWIDGET,
+        "config": {
+            "get_file_mode": True,  # False for folders
+            "filter": "Password file (*.pgpass *.conf)",
+            "title": "Select a .pgpass or .conf file",
+        },
+    },
+    "sslmode": {
+        "default": SslModeEnum.PREFER.value,
+        "description": "This option determines whether or with what priority a secure SSL TCP/IP connection will be negotiated with the server.",
+        "custom_type": WidgetTypeEnum.COMBOBOX,
+        "config": {"values": [e.value for e in SslModeEnum]},
+    },
+    "sslrootcert": {
+        "default": "",
+        "description": "Name of a file containing SSL certificate authority (CA) certificate(s).\nIf the file exists, the server's certificate will be verified to be signed by one of these authorities.",
+        "custom_type": WidgetTypeEnum.FILEWIDGET,
+        "config": {
+            "get_file_mode": True,  # False for folders
+            "filter": "SSL crt files (*.crt)",
+            "title": "Select the file pointing to SSL CA certificate(s)",
+        },
+    },
+    "sslcert": {
+        "default": "",
+        "description": "Specifies the file name of the client SSL certificate, replacing the default ~/.postgresql/postgresql.crt.\nThis parameter is ignored if an SSL connection is not made.",
+        "custom_type": WidgetTypeEnum.FILEWIDGET,
+        "config": {
+            "get_file_mode": True,  # False for folders
+            "filter": "SSL crt files (*.crt)",
+            "title": "Select the client SSL certificate file",
+        },
+    },
+    "sslkey": {
+        "default": "",
+        "description": "Specifies the location for the secret key used for the client certificate.\nIt can specify a file name that will be used instead of the default ~/.postgresql/postgresql.key\nThis parameter is ignored if an SSL connection is not made.",
+        "custom_type": WidgetTypeEnum.FILEWIDGET,
+        "config": {
+            "get_file_mode": True,  # False for folders
+            "filter": "SSL secret key files (*.key)",
+            "title": "Select the secret key file",
+        },
     },
 }
 

--- a/pg_service_parser/gui/item_delegates.py
+++ b/pg_service_parser/gui/item_delegates.py
@@ -1,9 +1,11 @@
 # Adapted from
 # https://github.com/xxyzz/WordDumb/blob/097dd6c1651fdc08b472e0bf639aec444b6e14ec/custom_lemmas.py#L398C1-L438C46
 
+from qgis.gui import QgsFileWidget
 from qgis.PyQt.QtCore import Qt
 from qgis.PyQt.QtWidgets import QComboBox, QStyledItemDelegate
 
+from pg_service_parser.conf.enums import WidgetTypeEnum
 from pg_service_parser.core.setting_model import ServiceConfigModel
 
 
@@ -12,16 +14,37 @@ class ServiceConfigDelegate(QStyledItemDelegate):
         super().__init__(parent)
 
     def createEditor(self, parent, option, index):
-        if ServiceConfigModel.is_sslmode_edit_cell(index):
-            options = list(index.data(Qt.ItemDataRole.UserRole).values())[0]
-            combo_box = QComboBox(parent)
-            if isinstance(options, list):
-                for value in options:
-                    combo_box.addItem(value, value)
+        if ServiceConfigModel.is_custom_widget_cell(index):
+            widget_type = index.data(Qt.ItemDataRole.UserRole)["custom_type"]
+            config = index.data(Qt.ItemDataRole.UserRole)["config"]
 
-            combo_box.currentIndexChanged.connect(self.commit_and_close_editor)
+            if widget_type == WidgetTypeEnum.COMBOBOX:
+                options = config["values"]
 
-            return combo_box
+                widget = QComboBox(parent)
+                if isinstance(options, list):
+                    for value in options:
+                        widget.addItem(value, value)
+
+                widget.currentIndexChanged.connect(self.commit_and_close_editor)
+                return widget
+
+            elif widget_type == WidgetTypeEnum.FILEWIDGET:
+                widget = QgsFileWidget(parent)
+                widget.setStorageMode(
+                    QgsFileWidget.GetFile
+                    if config.get("get_file_mode")
+                    else QgsFileWidget.GetDirectory
+                )
+
+                if widget.storageMode() == QgsFileWidget.GetFile:
+                    widget.setDialogTitle(config.get("title", "Select an existing file"))
+                    widget.setFilter(config.get("filter", ""))
+                else:
+                    widget.setDialogTitle(config.get("title", "Select an existing folder"))
+
+                widget.fileChanged.connect(self.commit_and_close_editor)
+                return widget
 
         return QStyledItemDelegate.createEditor(self, parent, option, index)
 
@@ -31,15 +54,27 @@ class ServiceConfigDelegate(QStyledItemDelegate):
         self.closeEditor.emit(editor)
 
     def setEditorData(self, editor, index):
-        if ServiceConfigModel.is_sslmode_edit_cell(index):
+        if ServiceConfigModel.is_custom_widget_cell(index):
+            widget_type = index.data(Qt.ItemDataRole.UserRole)["custom_type"]
             value = index.data(Qt.ItemDataRole.DisplayRole)
-            editor.setCurrentText(value)
+
+            if widget_type == WidgetTypeEnum.COMBOBOX:
+                editor.setCurrentText(value)
+            elif widget_type == WidgetTypeEnum.FILEWIDGET:
+                editor.setFilePath(value)
         else:
             QStyledItemDelegate.setEditorData(self, editor, index)
 
     def setModelData(self, editor, model, index):
-        if ServiceConfigModel.is_sslmode_edit_cell(index):
-            value = editor.currentData()
+        if ServiceConfigModel.is_custom_widget_cell(index):
+            widget_type = index.data(Qt.ItemDataRole.UserRole)["custom_type"]
+            value = ""
+
+            if widget_type == WidgetTypeEnum.COMBOBOX:
+                value = editor.currentData()
+            elif widget_type == WidgetTypeEnum.FILEWIDGET:
+                value = editor.filePath()
+
             model.setData(index, value, Qt.ItemDataRole.EditRole)
         else:
             QStyledItemDelegate.setModelData(self, editor, model, index)

--- a/pg_service_parser/ui/service_settings_dialog.ui
+++ b/pg_service_parser/ui/service_settings_dialog.ui
@@ -6,8 +6,8 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>226</width>
-    <height>205</height>
+    <width>299</width>
+    <height>286</height>
    </rect>
   </property>
   <property name="windowTitle">


### PR DESCRIPTION
 + Use QgsFileWidget to handle file path settings.
 + Add 3 new settings: sslrootcert, sslcert, sslkey

![image](https://github.com/user-attachments/assets/6777afd3-4acb-4598-8d9e-f51d83398ba0)


Fix #49 