### PR TITLE
fix space added around = operator

### DIFF
--- a/pg_service_parser/core/pg_service_parser_wrapper.py
+++ b/pg_service_parser/core/pg_service_parser_wrapper.py
@@ -82,7 +82,7 @@ def __create_service(
 
     config.add_section(service_name)
     with open(conf_file_path or pgserviceparser.conf_path(), "w") as f:
-        config.write(f)
+        config.write(f, space_around_delimiters=False)
 
     if service_name in config:
         pgserviceparser.write_service(service_name, settings, conf_file_path)


### PR DESCRIPTION
not 100% it came from here, but I ended up with a corrupted file after copy a service.
I didn't find any other occurrence.

