### PR TITLE
Refresh QGIS PG connections after creating/editing/removing a connection to a service

### DIFF
--- a/pg_service_parser/core/service_connections.py
+++ b/pg_service_parser/core/service_connections.py
@@ -50,3 +50,16 @@ def edit_connection(connection_name: str, parent: QWidget) -> None:
 
         widget.refresh()  # To reflect the newly selected connection
         widget.btnEdit_clicked()
+
+
+def refresh_connections(iface):
+    # Refresh PG connections in the browser
+    # and in the Data Source Manager.
+    browser = iface.browserModel()
+    index = browser.findPath("pg:")
+    if index.isValid():
+        postgres_item = browser.dataItem(index)  # QgsDataCollectionItem
+
+        # Emits a signal that notifies the browser and the
+        # data source manager to refresh PG connections
+        postgres_item.refreshConnections()

--- a/pg_service_parser/gui/dlg_pg_service.py
+++ b/pg_service_parser/gui/dlg_pg_service.py
@@ -18,6 +18,7 @@ from pg_service_parser.core.service_connections import (
     create_connection,
     edit_connection,
     get_connections,
+    refresh_connections,
     remove_connection,
 )
 from pg_service_parser.core.setting_model import ServiceConfigModel
@@ -41,9 +42,11 @@ where you have write permissions.
 
 
 class PgServiceDialog(QDialog, DIALOG_UI):
-    def __init__(self, shortcuts_model: ShortcutsModel, parent):
-        QDialog.__init__(self, parent)
+    def __init__(self, shortcuts_model: ShortcutsModel, iface):
+        QDialog.__init__(self, iface.mainWindow())
         self.setupUi(self)
+
+        self.iface = iface
 
         # Flag to handle initialization of new files
         self.__new_empty_file = False
@@ -404,6 +407,7 @@ class PgServiceDialog(QDialog, DIALOG_UI):
         if dlg.result() == QDialog.DialogCode.Accepted:
             create_connection(service, dlg.new_name)
             self.__initialize_service_connections()
+            self.__refresh_qgis_connections()
 
     @pyqtSlot()
     def __edit_connection_clicked(self):
@@ -419,6 +423,7 @@ class PgServiceDialog(QDialog, DIALOG_UI):
         connection_name = self.__connection_model.index_to_connection_key(index)
         edit_connection(connection_name, self)
         self.__initialize_service_connections(index)
+        self.__refresh_qgis_connections()
 
     @pyqtSlot()
     def __remove_connection_clicked(self):
@@ -437,6 +442,7 @@ class PgServiceDialog(QDialog, DIALOG_UI):
             ):
                 remove_connection(connection_name)
                 self.__initialize_service_connections()
+                self.__refresh_qgis_connections()
 
     @pyqtSlot(QItemSelection, QItemSelection)
     def __conn_table_selection_changed(self, selected, deselected):
@@ -450,3 +456,6 @@ class PgServiceDialog(QDialog, DIALOG_UI):
     @pyqtSlot(QItemSelection, QItemSelection)
     def __shortcuts_selection_changed(self, selected, deselected):
         self.shortcutRemoveButton.setEnabled(len(selected) > 0)
+
+    def __refresh_qgis_connections(self):
+        refresh_connections(self.iface)

--- a/pg_service_parser/pg_service_parser_plugin.py
+++ b/pg_service_parser/pg_service_parser_plugin.py
@@ -106,7 +106,7 @@ class PgServiceParserPlugin:
         QgsSettingsTree.unregisterPluginTreeNode(PLUGIN_NAME)
 
     def run(self):
-        dlg = PgServiceDialog(self.shortcuts_model, self.iface.mainWindow())
+        dlg = PgServiceDialog(self.shortcuts_model, self.iface)
         dlg.exec()
 
     def copy_service(self, service_from: str, service_to: str):


### PR DESCRIPTION
Current situation:

 + Users wonder where is the new connection or why it isn't shown in the Browser (until they understand they should click on the Refresh button).

 + The Data Source Manager gets refreshed connections list only when it's open the first time. Subsequent openings don't get refreshed connections list.

-------

This PR makes sure we refresh connections in both the QGIS browser and the Data Source Manager.

Follow-up #39 
