### PR TITLE
Improve passwords display and editing

### DIFF
--- a/pg_service_parser/conf/enums.py
+++ b/pg_service_parser/conf/enums.py
@@ -13,3 +13,4 @@ class SslModeEnum(Enum):
 class WidgetTypeEnum(Enum):
     COMBOBOX = 0
     FILEWIDGET = 1
+    PASSWORD = 2

--- a/pg_service_parser/conf/service_settings.py
+++ b/pg_service_parser/conf/service_settings.py
@@ -32,6 +32,7 @@ def SERVICE_SETTINGS():
             "description": QCoreApplication.translate(
                 "Plugin", "Password to be used if the server demands password authentication."
             ),
+            "custom_type": WidgetTypeEnum.PASSWORD,
         },
         "passfile": {
             "default": "",

--- a/pg_service_parser/core/connection_model.py
+++ b/pg_service_parser/core/connection_model.py
@@ -1,4 +1,4 @@
-from qgis.core import QgsAbstractDatabaseProviderConnection
+from qgis.core import QgsAbstractDatabaseProviderConnection, QgsDataSourceUri
 from qgis.PyQt.QtCore import QAbstractTableModel, QModelIndex, Qt
 from qgis.PyQt.QtGui import QFont
 
@@ -23,6 +23,18 @@ class ServiceConnectionModel(QAbstractTableModel):
     def index_to_connection_key(self, index):
         return list(self.__model_data.keys())[index.row()]
 
+    def clean_uri(self, uri_string: str) -> str:
+        """
+        Clean a datasource URI by removing password
+        """
+        cleaned_uri = QgsDataSourceUri.removePassword(uri_string, True)
+        # Awkward, but we must also manually remove the password.
+        # In some cases, the method does not work
+        uri = QgsDataSourceUri(uri_string)
+        cleaned_uri = cleaned_uri.replace(f"password='{uri.password()}'", "password='XXXXXXX'")
+
+        return cleaned_uri
+
     def data(self, index, role=Qt.ItemDataRole.DisplayRole):
         if not index.isValid():
             return None
@@ -32,7 +44,7 @@ class ServiceConnectionModel(QAbstractTableModel):
             if index.column() == self.KEY_COL:
                 return key
             elif index.column() == self.VALUE_COL:
-                return self.__model_data[key].uri()
+                return self.clean_uri(self.__model_data[key].uri())
         elif role == Qt.ItemDataRole.FontRole:
             if index.column() == self.KEY_COL:
                 font = QFont()
@@ -44,7 +56,7 @@ class ServiceConnectionModel(QAbstractTableModel):
                 return font
         elif role == Qt.ItemDataRole.ToolTipRole:
             if index.column() == self.VALUE_COL:
-                return self.__model_data[key].uri()
+                return self.clean_uri(self.__model_data[key].uri())
 
         return None
 

--- a/pg_service_parser/core/setting_model.py
+++ b/pg_service_parser/core/setting_model.py
@@ -62,7 +62,12 @@ class ServiceConfigModel(QAbstractTableModel):
             if index.column() == self.KEY_COL:
                 return key
             elif index.column() == self.VALUE_COL:
-                return self.__model_data[key]
+                setting = self.__settings_data.get(key, {})
+                return (
+                    "************"
+                    if setting.get("custom_type") == WidgetTypeEnum.PASSWORD
+                    else self.__model_data[key]
+                )
         elif role == Qt.ItemDataRole.ToolTipRole:
             if index.column() == self.KEY_COL:
                 return (


### PR DESCRIPTION
* Obfuscate passwords in "Edit Service" and "QGIS Connections" tab
* Use `QgsPasswordLineEdit` to edit the password, password hidden by default

Fixes #86 